### PR TITLE
Refactor RayWeb template and validate domains

### DIFF
--- a/raygate/opt/bin/raygate/rayweb/templates/index.html
+++ b/raygate/opt/bin/raygate/rayweb/templates/index.html
@@ -1,0 +1,169 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>RayGate VPN Manager</title>
+    <style>
+        body {
+            font-family: 'Segoe UI', Tahoma, sans-serif;
+            background-color: #0d1117;
+            color: #e6edf3;
+            margin: 0;
+            padding: 0;
+            text-align: center;
+        }
+        h2, h3 {
+            color: #58a6ff;
+        }
+        a {
+            color: #f55;
+            text-decoration: none;
+        }
+        .container {
+            padding: 20px;
+        }
+        .control-line {
+            display: flex;
+            justify-content: center;
+            gap: 10px;
+            margin-bottom: 25px;
+            flex-wrap: wrap;
+        }
+        form {
+            display: inline-block;
+            margin: 0;
+        }
+        input[type="text"], input[type="password"] {
+            padding: 6px 10px;
+            border: 1px solid #30363d;
+            border-radius: 5px;
+            background-color: #161b22;
+            color: #e6edf3;
+        }
+        button {
+            padding: 6px 12px;
+            border: none;
+            border-radius: 5px;
+            cursor: pointer;
+            background-color: #21262d;
+            color: #e6edf3;
+            transition: background 0.2s ease;
+        }
+        button:hover {
+            background-color: #30363d;
+        }
+        .btn-red {
+            background-color: #da3633;
+        }
+        .btn-red:hover {
+            background-color: #f85149;
+        }
+        table {
+            margin: auto;
+            border-collapse: collapse;
+            width: 100%;
+            background-color: #161b22;
+            border-radius: 6px;
+            overflow: hidden;
+        }
+        td {
+            padding: 8px;
+            border-bottom: 1px solid #30363d;
+        }
+        tr:hover {
+            background-color: #21262d;
+        }
+        pre {
+            text-align: left;
+            margin: auto;
+            background-color: #161b22;
+            padding: 12px;
+            border-radius: 6px;
+            overflow-x: auto;
+            font-size: 14px;
+        }
+        .scroll-box {
+            max-height: 300px;
+            overflow-y: auto;
+            border: 1px solid #30363d;
+            border-radius: 6px;
+            margin: auto;
+            width: 80%;
+            text-align: left;
+        }
+        .tag-header {
+            background-color: #21262d;
+            padding: 6px 10px;
+            font-weight: bold;
+            border-bottom: 1px solid #30363d;
+            position: sticky;
+            top: 0;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+    {% if not session.get('logged_in') %}
+        <h2>🔑 RayWeb Manager</h2>
+        <form method="POST" action="{{ url_for('login') }}">
+            <input type="text" name="username" placeholder="Username"><br><br>
+            <input type="password" name="password" placeholder="Password"><br><br>
+            <button type="submit">Login</button>
+        </form>
+    {% else %}
+        <h3>🖥 Command Output</h3>
+        <pre>{{ output }}</pre>
+
+        <div class="control-line">
+            <!-- XRAY Control -->
+            <form method="POST" action="{{ url_for('xray_control') }}">
+                <button name="action" value="start">▶ Start</button>
+                <button name="action" value="stop">⏹ Stop</button>
+                <button name="action" value="restart">🔄 Restart</button>
+                <button name="action" value="status">ℹ Status</button>
+            </form>
+
+            <!-- Add domain -->
+            <form method="POST" action="{{ url_for('add_domain') }}">
+                <input type="text" name="domain" placeholder="example.com" required>
+                <button type="submit">➕ Add</button>
+            </form>
+
+            <!-- Check IP -->
+            <form method="POST" action="{{ url_for('check_ip') }}">
+                <button type="submit">🌐 Check External IP's</button>
+            </form>
+        </div>
+
+        <h2>📜 Current Domains in VPN</h2>
+        <div class="scroll-box">
+            {% for tag, dom_list in grouped_domains.items() %}
+                <div class="tag-header">{{ tag }}</div>
+                <table>
+                    {% for domain in dom_list %}
+                    <tr>
+                        <td style="width:80%">{{ domain }}</td>
+                        <td>
+                            <form method="POST" action="{{ url_for('remove_domain') }}" style="display:inline;">
+                                <input type="hidden" name="domain" value="{{ domain }}">
+                                <button type="submit" class="btn-red">🗑 Remove</button>
+                            </form>
+                        </td>
+                    </tr>
+                    {% endfor %}
+                </table>
+            {% endfor %}
+        </div>
+
+        <h3>📦 Current IPSet</h3>
+        <div class="scroll-box">
+            <pre>{{ ipset_list }}</pre>
+        </div>
+
+        <br>
+        <a href="{{ url_for('logout') }}">🚪 Logout</a>
+    {% endif %}
+    </div>
+</body>
+</html>
+


### PR DESCRIPTION
## Summary
- render RayWeb from external `templates/index.html` instead of inline string
- remove unused `socket` import and add regex-based domain validation
- switch all views to use `render_template`

## Testing
- `python -m py_compile raygate/opt/bin/raygate/rayweb/rayweb.py`


------
https://chatgpt.com/codex/tasks/task_e_689a220b234c832d9c3a323f99d3c87e