### PR TITLE
refactor: use DOMAIN in raygate_add

### DIFF
--- a/raygate/opt/bin/raygate/raygate_add.sh
+++ b/raygate/opt/bin/raygate/raygate_add.sh
@@ -1,13 +1,15 @@
 #!/bin/sh
 
-TAG="$1"
+DOMAIN="$1"
+TAG="${DOMAIN%%.*}"
 CONF_DIR="/opt/etc/dnsmasq.d"
 CONF="$CONF_DIR/90-vpn-domains.conf"
 SET4="vpn_domains"
 IPSET_FILE="/opt/etc/vpn_domains.ipset"
+META_FILE="/opt/etc/vpn_domains.meta"
 DNS_PORT=5354
 
-if [ -z "$TAG" ]; then
+if [ -z "$DOMAIN" ]; then
   echo "Usage: $0 <domain>"
   exit 1
 fi
@@ -21,12 +23,12 @@ if ! ipset list "$SET4" >/dev/null 2>&1; then
 fi
 
 # Запись в dnsmasq.conf
-ENTRY="ipset=/$TAG/$SET4"
+ENTRY="ipset=/$DOMAIN/$SET4"
 grep -qxF "$ENTRY" "$CONF" || echo "$ENTRY" >> "$CONF"
 
 # Резолвим домен → IP → добавляем в ipset
 ADDED=0
-for ip in $(dig +tcp @"127.0.0.1" -p "$DNS_PORT" "$TAG" A +short); do
+for ip in $(dig +tcp @"127.0.0.1" -p "$DNS_PORT" "$DOMAIN" A +short); do
   if ipset add "$SET4" "$ip" 2>/dev/null; then
     ADDED=$((ADDED+1))
   fi
@@ -38,12 +40,12 @@ pidof dnsmasq >/dev/null && kill -HUP "$(pidof dnsmasq)"
 # Сохраняем ipset
 ipset save "$SET4" > "$IPSET_FILE"
 
-echo "✅ Домен $TAG добавлен в VPN (новых IP: $ADDED)"
+echo "✅ Домен $DOMAIN добавлен в VPN (новых IP: $ADDED)"
 
 # === Запись в META файл ===
 [ ! -f "$META_FILE" ] && touch "$META_FILE"
-TAG=$(echo "$DOMAIN" | awk -F. '{print $1}')
 if ! grep -q "^$DOMAIN," "$META_FILE"; then
     echo "$DOMAIN,$TAG" >> "$META_FILE"
     echo "💾 Added to meta: $DOMAIN ($TAG)"
 fi
+


### PR DESCRIPTION
## Summary
- store input domain in DOMAIN and compute TAG only once
- add explicit META_FILE path and use DOMAIN for ipset and META entries

## Testing
- `shellcheck raygate/opt/bin/raygate/raygate_add.sh`

------
https://chatgpt.com/codex/tasks/task_e_689a231a81ac832dbac4a475d7ca3ee0