### PR TITLE
Fix tag extraction for domains in raygate_add.sh

### DIFF
--- a/raygate/opt/bin/raygate/raygate_add.sh
+++ b/raygate/opt/bin/raygate/raygate_add.sh
@@ -1,7 +1,9 @@
 #!/bin/sh
 
 DOMAIN="$1"
-TAG="${DOMAIN%%.*}"
+# Используем домен второго уровня в качестве тега
+TAG="${DOMAIN%.*}"
+TAG="${TAG##*.}"
 CONF_DIR="/opt/etc/dnsmasq.d"
 CONF="$CONF_DIR/90-vpn-domains.conf"
 SET4="vpn_domains"


### PR DESCRIPTION
## Summary
- Derive tag from second-level domain instead of first label when adding VPN domains.

## Testing
- `shellcheck raygate/opt/bin/raygate/raygate_add.sh`
- `DOMAIN=auth.openai.com; TAG="${DOMAIN%.*}"; TAG="${TAG##*.}"; echo $TAG`

------
https://chatgpt.com/codex/tasks/task_e_689a442226dc832d9d6726d69c3cd473