### PR TITLE
Add removal mode handling and sanitize mode input

### DIFF
--- a/raygate/opt/bin/raygate/raygate_rem.sh
+++ b/raygate/opt/bin/raygate/raygate_rem.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 DOMAIN="$1"
+MODE="${2:-full}"
 CONF="/opt/etc/dnsmasq.d/90-vpn-domains.conf"
 SET4="vpn_domains"
 IPSET_FILE="/opt/etc/vpn_domains.ipset"
@@ -8,29 +9,37 @@ DNS_PORT=5354
 META_FILE="/opt/etc/vpn_domains.meta"
 
 if [ -z "$DOMAIN" ]; then
-  echo "Usage: $0 <domain>"
+  echo "Usage: $0 <domain> [mode]"
   exit 1
 fi
 
-# Удаляем из dnsmasq.conf
-sed -i "\|ipset=/$DOMAIN/$SET4|d" "$CONF"
+case "$MODE" in
+  full)
+    # Удаляем из dnsmasq.conf
+    sed -i "\\|ipset=/$DOMAIN/$SET4|d" "$CONF"
 
-# Удаляем IP из ipset
-REMOVED=0
-for ip in $(dig +tcp @"127.0.0.1" -p "$DNS_PORT" "$DOMAIN" A +short); do
-  if ipset del "$SET4" "$ip" 2>/dev/null; then
-    REMOVED=$((REMOVED+1))
-  fi
-done
+    # Удаляем IP из ipset
+    REMOVED=0
+    for ip in $(dig +tcp @"127.0.0.1" -p "$DNS_PORT" "$DOMAIN" A +short); do
+      if ipset del "$SET4" "$ip" 2>/dev/null; then
+        REMOVED=$((REMOVED+1))
+      fi
+    done
 
-# Обновляем META-файл
-[ -f "$META_FILE" ] && sed -i "\|^$DOMAIN,|d" "$META_FILE"
+    # Обновляем META-файл
+    [ -f "$META_FILE" ] && sed -i "\\|^$DOMAIN,|d" "$META_FILE"
 
-# Перечитываем dnsmasq
-pidof dnsmasq >/dev/null && kill -HUP "$(pidof dnsmasq)"
+    # Перечитываем dnsmasq
+    pidof dnsmasq >/dev/null && kill -HUP "$(pidof dnsmasq)"
 
-# Сохраняем ipset
-ipset save "$SET4" > "$IPSET_FILE"
+    # Сохраняем ipset
+    ipset save "$SET4" > "$IPSET_FILE"
 
-echo "❌ Домен $DOMAIN удалён из VPN (IP удалено: $REMOVED)"
+    echo "❌ Домен $DOMAIN удалён из VPN (IP удалено: $REMOVED)"
+    ;;
+  *)
+    echo "Unsupported mode: $MODE"
+    exit 1
+    ;;
+esac
 

--- a/raygate/opt/bin/raygate/rayweb/rayweb.py
+++ b/raygate/opt/bin/raygate/rayweb/rayweb.py
@@ -18,6 +18,7 @@ IPSET_LIST_CMD = ["ipset", "list", "vpn_domains"]
 IPSET_SAVE_CMD = ["ipset", "save", "vpn_domains"]
 IPSET_FILE = "/opt/etc/vpn_domains.ipset"
 WAN_INTERFACE = "eth3"
+REM_SUPPORTED_MODES = {"full"}
 
 app = Flask(__name__, static_folder='static')
 app.secret_key = SECRET_KEY
@@ -112,6 +113,8 @@ def remove_domain():
         return redirect(url_for("index"))
     domain = request.form.get("domain")
     mode = request.form.get("mode", "full")
+    if mode not in REM_SUPPORTED_MODES:
+        mode = "full"
 
     # Удаляем через скрипт
     try:

--- a/raygate/opt/bin/raygate/rayweb/templates/index.html
+++ b/raygate/opt/bin/raygate/rayweb/templates/index.html
@@ -164,6 +164,7 @@
                         <td>
                             <form method="POST" action="{{ url_for('remove_domain') }}" style="display:inline;">
                                 <input type="hidden" name="domain" value="{{ domain }}">
+                                <input type="hidden" name="mode" value="full">
                                 <button type="submit" class="btn-red">🗑 Remove</button>
                             </form>
                         </td>


### PR DESCRIPTION
## Summary
- Allow `raygate_rem.sh` to accept an optional mode parameter, defaulting to `full` and rejecting unsupported values.
- Pass removal mode from the web UI with a hidden field.
- Validate mode in `remove_domain` and restrict to known values.

## Testing
- `python -m py_compile raygate/opt/bin/raygate/rayweb/rayweb.py`
- `bash -n raygate/opt/bin/raygate/raygate_rem.sh`


------
https://chatgpt.com/codex/tasks/task_e_689a574e88f8832dbfcf85bd80eda50d