### PR TITLE
Fix status command output

### DIFF
--- a/raygate/opt/etc/init.d/S99raygate
+++ b/raygate/opt/etc/init.d/S99raygate
@@ -189,6 +189,9 @@ start)
         echo "⚠️ rayweb is not running"
     fi
 
+    ;;
+
+  *)
     echo "Usage: $0 {start|stop|restart|status}"
     exit 1
     ;;


### PR DESCRIPTION
## Summary
- remove unused usage message from status command
- add default case to print usage for invalid arguments

## Testing
- `sh -n raygate/opt/etc/init.d/S99raygate`
- `sh raygate/opt/etc/init.d/S99raygate status`
- `sh raygate/opt/etc/init.d/S99raygate foo`


------
https://chatgpt.com/codex/tasks/task_e_689a604035d4832dba223fe4da849e8e