### PR TITLE
Gracefully handle missing ipset command

### DIFF
--- a/raygate/opt/bin/raygate/rayweb/rayweb.py
+++ b/raygate/opt/bin/raygate/rayweb/rayweb.py
@@ -52,6 +52,8 @@ def get_ipset_list():
         return subprocess.check_output(IPSET_LIST_CMD, stderr=subprocess.STDOUT, text=True)
     except subprocess.CalledProcessError as e:
         return e.output
+    except FileNotFoundError:
+        return ""
 
 # ==== Главная ====
 @app.route("/", methods=["GET"])


### PR DESCRIPTION
## Summary
- avoid crashing when ipset is unavailable by catching FileNotFoundError

## Testing
- `python -m py_compile bin/raygate/rayweb/rayweb.py`
- `python - <<'PY'
from bin.raygate.rayweb.rayweb import app
client = app.test_client()
with client:
    with client.session_transaction() as sess:
        sess['logged_in'] = True
    resp = client.post('/remove', data={'domain':'example.com','mode':'full'})
    print('status', resp.status_code)
    print('data snippet', resp.data.decode('utf-8')[:100])
PY`


------
https://chatgpt.com/codex/tasks/task_e_689a6320ca30832d819490a3d9721752