### PR TITLE
Simplify domain removal handling

### DIFF
--- a/raygate/opt/bin/raygate/raygate_rem.sh
+++ b/raygate/opt/bin/raygate/raygate_rem.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 
 DOMAIN="$1"
-MODE="${2:-full}"
 CONF="/opt/etc/dnsmasq.d/90-vpn-domains.conf"
 SET4="vpn_domains"
 IPSET_FILE="/opt/etc/vpn_domains.ipset"
@@ -9,37 +8,29 @@ DNS_PORT=5354
 META_FILE="/opt/etc/vpn_domains.meta"
 
 if [ -z "$DOMAIN" ]; then
-  echo "Usage: $0 <domain> [mode]"
+  echo "Usage: $0 <domain>"
   exit 1
 fi
 
-case "$MODE" in
-  full)
-    # Удаляем из dnsmasq.conf
-    sed -i "\\|ipset=/$DOMAIN/$SET4|d" "$CONF"
+# Удаляем из dnsmasq.conf
+sed -i "\\|ipset=/$DOMAIN/$SET4|d" "$CONF"
 
-    # Удаляем IP из ipset
-    REMOVED=0
-    for ip in $(dig +tcp @"127.0.0.1" -p "$DNS_PORT" "$DOMAIN" A +short); do
-      if ipset del "$SET4" "$ip" 2>/dev/null; then
-        REMOVED=$((REMOVED+1))
-      fi
-    done
+# Удаляем IP из ipset
+REMOVED=0
+for ip in $(dig +tcp @"127.0.0.1" -p "$DNS_PORT" "$DOMAIN" A +short); do
+  if ipset del "$SET4" "$ip" 2>/dev/null; then
+    REMOVED=$((REMOVED+1))
+  fi
+done
 
-    # Обновляем META-файл
-    [ -f "$META_FILE" ] && sed -i "\\|^$DOMAIN,|d" "$META_FILE"
+# Обновляем META-файл
+[ -f "$META_FILE" ] && sed -i "\\|^$DOMAIN,|d" "$META_FILE"
 
-    # Перечитываем dnsmasq
-    pidof dnsmasq >/dev/null && kill -HUP "$(pidof dnsmasq)"
+# Перечитываем dnsmasq
+pidof dnsmasq >/dev/null && kill -HUP "$(pidof dnsmasq)"
 
-    # Сохраняем ipset
-    ipset save "$SET4" > "$IPSET_FILE"
+# Сохраняем ipset
+ipset save "$SET4" > "$IPSET_FILE"
 
-    echo "❌ Домен $DOMAIN удалён из VPN (IP удалено: $REMOVED)"
-    ;;
-  *)
-    echo "Unsupported mode: $MODE"
-    exit 1
-    ;;
-esac
+echo "❌ Домен $DOMAIN удалён из VPN (IP удалено: $REMOVED)"
 

--- a/raygate/opt/bin/raygate/rayweb/rayweb.py
+++ b/raygate/opt/bin/raygate/rayweb/rayweb.py
@@ -18,7 +18,6 @@ IPSET_LIST_CMD = ["ipset", "list", "vpn_domains"]
 IPSET_SAVE_CMD = ["ipset", "save", "vpn_domains"]
 IPSET_FILE = "/opt/etc/vpn_domains.ipset"
 WAN_INTERFACE = "eth3"
-REM_SUPPORTED_MODES = {"full"}
 
 app = Flask(__name__, static_folder='static')
 app.secret_key = SECRET_KEY
@@ -114,9 +113,6 @@ def remove_domain():
     if not session.get("logged_in"):
         return redirect(url_for("index"))
     domain = request.form.get("domain", "").strip()
-    mode = request.form.get("mode", "full")
-    if mode not in REM_SUPPORTED_MODES:
-        mode = "full"
 
     if not domain:
         result = "Domain is required"
@@ -125,7 +121,7 @@ def remove_domain():
         script_failed = False
         try:
             result = subprocess.check_output(
-                [XRAY_REM_SCRIPT, domain, mode], stderr=subprocess.STDOUT, text=True
+                [XRAY_REM_SCRIPT, domain], stderr=subprocess.STDOUT, text=True
             )
         except subprocess.CalledProcessError as e:
             result = e.output

--- a/raygate/opt/bin/raygate/rayweb/templates/index.html
+++ b/raygate/opt/bin/raygate/rayweb/templates/index.html
@@ -164,7 +164,6 @@
                         <td>
                             <form method="POST" action="{{ url_for('remove_domain') }}" style="display:inline;">
                                 <input type="hidden" name="domain" value="{{ domain }}">
-                                <input type="hidden" name="mode" value="full">
                                 <button type="submit" class="btn-red">🗑 Remove</button>
                             </form>
                         </td>


### PR DESCRIPTION
## Summary
- remove unused mode parameter from domain removal script
- update web UI and backend to call removal script without mode

## Testing
- `bash -n raygate/opt/bin/raygate/raygate_rem.sh`
- `python -m py_compile raygate/opt/bin/raygate/rayweb/rayweb.py`


------
https://chatgpt.com/codex/tasks/task_e_689a6728b548832db432acc74d6f2634